### PR TITLE
Changed MessageEvent.payload to Map

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.github.yvasyliev</groupId>
     <artifactId>java-vk-bots-longpoll-api</artifactId>
     <packaging>jar</packaging>
-    <version>1.5.1</version>
+    <version>1.5.2</version>
 
     <name>Java VK Bots Long Poll API</name>
     <description>A Java library to create VK bots using Bots Long Poll API</description>

--- a/src/main/java/api/longpoll/bots/model/events/messages/MessageEvent.java
+++ b/src/main/java/api/longpoll/bots/model/events/messages/MessageEvent.java
@@ -3,6 +3,8 @@ package api.longpoll.bots.model.events.messages;
 import api.longpoll.bots.model.events.EventObject;
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Map;
+
 /**
  * Action with message. Used to work with Callback buttons.
  */
@@ -29,7 +31,7 @@ public class MessageEvent implements EventObject {
      * Additional info.
      */
     @SerializedName("payload")
-    private String payload;
+    private Map<String, Object> payload;
 
     /**
      * Message ID.
@@ -61,11 +63,11 @@ public class MessageEvent implements EventObject {
         this.eventId = eventId;
     }
 
-    public String getPayload() {
+    public Map<String, Object> getPayload() {
         return payload;
     }
 
-    public void setPayload(String payload) {
+    public void setPayload(Map<String, Object> payload) {
         this.payload = payload;
     }
 

--- a/src/main/java/api/longpoll/bots/model/events/messages/MessageEvent.java
+++ b/src/main/java/api/longpoll/bots/model/events/messages/MessageEvent.java
@@ -1,9 +1,8 @@
 package api.longpoll.bots.model.events.messages;
 
 import api.longpoll.bots.model.events.EventObject;
+import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
-
-import java.util.Map;
 
 /**
  * Action with message. Used to work with Callback buttons.
@@ -31,7 +30,7 @@ public class MessageEvent implements EventObject {
      * Additional info.
      */
     @SerializedName("payload")
-    private Map<String, Object> payload;
+    private JsonObject payload;
 
     /**
      * Message ID.
@@ -63,11 +62,11 @@ public class MessageEvent implements EventObject {
         this.eventId = eventId;
     }
 
-    public Map<String, Object> getPayload() {
+    public JsonObject getPayload() {
         return payload;
     }
 
-    public void setPayload(Map<String, Object> payload) {
+    public void setPayload(JsonObject payload) {
         this.payload = payload;
     }
 


### PR DESCRIPTION
Since Button.Action setPayload can not take just a string, only a JSON object (otherwise vk api returns error), MessageEvent's payload should be an object too. Without this fix, a RuntimeError occures: "Expected a string but was BEGIN_OBJECT". Tested locally.