### PR TITLE
Revert "Changed MessageEvent.payload to Map"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.github.yvasyliev</groupId>
     <artifactId>java-vk-bots-longpoll-api</artifactId>
     <packaging>jar</packaging>
-    <version>1.5.2</version>
+    <version>1.5.1</version>
 
     <name>Java VK Bots Long Poll API</name>
     <description>A Java library to create VK bots using Bots Long Poll API</description>

--- a/src/main/java/api/longpoll/bots/model/events/messages/MessageEvent.java
+++ b/src/main/java/api/longpoll/bots/model/events/messages/MessageEvent.java
@@ -1,7 +1,6 @@
 package api.longpoll.bots.model.events.messages;
 
 import api.longpoll.bots.model.events.EventObject;
-import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -30,7 +29,7 @@ public class MessageEvent implements EventObject {
      * Additional info.
      */
     @SerializedName("payload")
-    private JsonObject payload;
+    private String payload;
 
     /**
      * Message ID.
@@ -62,11 +61,11 @@ public class MessageEvent implements EventObject {
         this.eventId = eventId;
     }
 
-    public JsonObject getPayload() {
+    public String getPayload() {
         return payload;
     }
 
-    public void setPayload(JsonObject payload) {
+    public void setPayload(String payload) {
         this.payload = payload;
     }
 


### PR DESCRIPTION
Test failed:
```java
@Override
public void onMessageNew(MessageNewEvent messageNewEvent) {
    try {
        Keyboard keyboard = new Keyboard()
                .setInline(true)
                .setButtons(Collections.singletonList(Collections.singletonList(
                        new Button(new Button.CallbackAction("click me"))
                )));
        new MessagesSend(getAccessToken())
                .setPeerId(messageNewEvent.getMessage().getPeerId())
                .setMessage("answer")
                .setKeyboard(keyboard)
                .execute();
    } catch (BotsLongPollAPIException | BotsLongPollException e) {
        log.error("Error.", e);
    }
}

@Override
public void onMessageEvent(MessageEvent messageEvent) {
    System.out.println(messageEvent);
}
```

Gor error:
```
Exception in thread "main" com.google.gson.JsonSyntaxException: Expected a com.google.gson.JsonObject but was com.google.gson.JsonPrimitive
	at com.google.gson.internal.bind.TypeAdapters$35$1.read(TypeAdapters.java:897)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:131)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:222)
	at com.google.gson.Gson.fromJson(Gson.java:932)
	at com.google.gson.Gson.fromJson(Gson.java:1003)
	at com.google.gson.internal.bind.TreeTypeAdapter$GsonContextImpl.deserialize(TreeTypeAdapter.java:162)
	at api.longpoll.bots.adapters.deserializers.EventDeserializer.deserialize(EventDeserializer.java:58)
	at api.longpoll.bots.adapters.deserializers.EventDeserializer.deserialize(EventDeserializer.java:46)
	at com.google.gson.internal.bind.TreeTypeAdapter.read(TreeTypeAdapter.java:69)
	at com.google.gson.TypeAdapter$1.read(TypeAdapter.java:199)
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:41)
	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:82)
	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:61)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:131)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:222)
	at com.google.gson.Gson.fromJson(Gson.java:932)
	at com.google.gson.Gson.fromJson(Gson.java:1003)
	at com.google.gson.Gson.fromJson(Gson.java:975)
	at api.longpoll.bots.methods.VkApiMethod.execute(VkApiMethod.java:79)
	at api.longpoll.bots.methods.VkApiMethod.execute(VkApiMethod.java:61)
	at api.longpoll.bots.server.LongPollClient.getUpdates(LongPollClient.java:36)
	at api.longpoll.bots.server.InitializedLongPollClient.getUpdates(InitializedLongPollClient.java:23)
	at api.longpoll.bots.BotsLongPoll.run(BotsLongPoll.java:26)
	at BotTest.main(BotTest.java:81)
```

Received JSON:
```json
{
   "ts":"3458",
   "updates":[
      {
         "type":"message_event",
         "object":{
            "user_id":918650328,
            "peer_id":918650328,
            "event_id":"65e162c9f89e",
            "payload":"",
            "conversation_message_id":814
         },
         "group_id":886761559,
         "event_id":"7f9564d350acfd440f1b5873df99d20e0a355cc4"
      }
   ]
}
```
